### PR TITLE
faster dependency resolving

### DIFF
--- a/src/main/conscript/herald/launchconfig
+++ b/src/main/conscript/herald/launchconfig
@@ -8,4 +8,4 @@
 [repositories]
   local
   maven-central
-  scala-tools-releases
+  sonatype-releases: https://oss.sonatype.org/service/local/repositories/releases/content/


### PR DESCRIPTION
swapped out scala-tools-releases alias with the sonatype uri
