### PR TITLE
use pegdown for markdown conversion

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ description :=
 
 
 libraryDependencies ++= Seq(
-                    "com.tristanhunt" %% "knockoff" % "0.8.0-16",
+                    "org.pegdown" % "pegdown" % "1.1.0",
                     "net.databinder" %% "unfiltered-netty-server" % "0.6.2",
                     "net.liftweb" %% "lift-json" % "2.4",
                     "net.databinder.dispatch" %% "core" % "0.9.0-alpha6",

--- a/src/main/scala/herald.scala
+++ b/src/main/scala/herald.scala
@@ -3,10 +3,11 @@ package herald
 import dispatch._
 import java.net.URI
 import java.io.{File,FileInputStream}
-import com.tristanhunt.knockoff.DefaultDiscounter._
 import org.streum.configrity._
-import scala.xml.{NodeSeq,Node}
 import scala.util.control.Exception.allCatch
+import xml.{XML, NodeSeq, Node}
+import org.pegdown.PegDownProcessor
+
 object Herald {
   def heraldCredentialsPath = 
     file(new File(System.getProperty("user.home")), ".herald")
@@ -121,16 +122,17 @@ object Herald {
       mdToXml(versionNotes) ++
         <div class="about"> { mdToXml(about) } </div>
 
+  val pegDown = new PegDownProcessor
   /** @return node sequence from str or Nil if str is null or empty. */
-  private def mdToXml(str: String) = str match {
+  private def mdToXml(str: String): NodeSeq = str match {
     case null | "" => Nil
-    case _ => toXML(knockoff(str))
+    case _ => XML.loadString("<wrapper>"+pegDown.markdownToHtml(str)+"</wrapper>").iterator.toSeq
   }   
 
   /** @return node sequence from file or Nil if file is not found. */
-  private def mdToXml(md: File) =
+  private def mdToXml(md: File): NodeSeq =
     if (md.exists)
-      toXML(knockoff(scala.io.Source.fromFile(md).mkString))
+      mdToXml(scala.io.Source.fromFile(md).mkString)
     else
       Nil
 


### PR DESCRIPTION
I don't know if this is controversial but it seems that knockoff supports just a subset of the usual markdown syntax. For example, I'm always wondering which link syntax works and how to have monospaced text etc.

Here's a simple conversion to pegdown which supports a wider range of markdown syntax.
